### PR TITLE
chore: add HeistContractTargetItem

### DIFF
--- a/ItemData.cs
+++ b/ItemData.cs
@@ -99,6 +99,7 @@ public partial class ItemData
     public string Name { get; } = string.Empty;
     public string PublicPrice { get; } = string.Empty;
     public string HeistContractJobType { get; } = string.Empty;
+    public string HeistContractTargetItem { get; } = string.Empty;
     public int ItemQuality { get; } = 0;
     public int VeiledModCount { get; } = 0;
     public int FracturedModCount { get; } = 0;
@@ -390,6 +391,7 @@ public partial class ItemData
         {
             HeistContractJobType = heistComp.RequiredJob?.Name ?? "";
             HeistContractReqJobLevel = heistComp.RequiredJobLevel;
+            HeistContractTargetItem = heistComp.TargetItem?.BaseName ?? "";
         }
 
         if (item.TryGetComponent<Charges>(out var chargesComp))


### PR DESCRIPTION
- Adds HeistContractTargetItem aka `Entity.GetComponent<HeistContract>.TargetItem.BaseName`

Debatable to merge all of these Heist things into a Heist section, but wouldn't be backwards compatible.